### PR TITLE
Check for module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ function realRequire(deps, baseMod, middlewareName, name, options) {
 		try {
 			mod = baseMod.require(name);
 		} catch (error) {
-			if (error.code === 'MODULE_NOT_FOUND') {
+			if (error.code === 'MODULE_NOT_FOUND' &&
+				error.message.indexOf(mod) > -1
+			) {
 				isInstalled = false;
 			} else {
 				// there was an error in the module itself


### PR DESCRIPTION
I had an exception being swallowed in codependency.

The problem was that I published ringpop@3.0.4 and forgot to npm i hammock --save. The `ringpop` dependency was properly peer installed it was just that requiring it failed because dependencies it required failed.

codependency should only cast the exception into a "forgot to install peer dep" if the module name is in the error message.

cc @Wizcorp @ronkorving 