### PR TITLE
Fixed issue with requiring non-entrypoint files

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ var semver = require('semver');
  */
 
 function realResolve(deps, baseMod, name) {
+	var pos;
+
+	if (~(pos = name.indexOf('/'))) {
+		name = name.slice(0, pos);
+	}
+
 	var range = deps[name];
 
 	var resolved = {


### PR DESCRIPTION
When requiring non-entrypoint files, `codependency` bahaves incorrectly. For example, requiring `babel/register`, which is resolved to `node_modules/babel/register.js`, throws an exception.

```
Error: Module "babel/register" required by "gulpget" not found. Please run: npm install babel/register --save
```

This issue occurs because the path to `package.json` file of the required module is miscalculated. In the above example, it should be `node_modules/babel/package.json`, but in reality it was `node_modules/babel/register/package.json`.

Please review the fix and publish new version to `npm`. Thank you.
