### PR TITLE
add strictCheck option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,6 +83,9 @@ The `options` object may contain an `index` property, which defaults to the arra
 ["optionalPeerDependencies"]. Override it to change which properties of your package.json will be
 used to index.
 
+If the `module` argument is not the root module you may set the `options.strictCheck` property to `false`
+to search for `package.json` in a parent directory.
+
 This function returns a `require` function, which has the following signature:
 
 **requirePeer(name, options)**

--- a/index.js
+++ b/index.js
@@ -276,13 +276,15 @@ var middlewares = {};
  * Creates a require function for peer dependencies based on the package.json requirements for the
  * given middleware module.
  *
- * @param {Module}   baseModule      The module that hosts the dependencies.
- * @param {Object}   [options]       Options object
- * @param {string[]} [options.index] Which dependencies to evaluate.
- *                                   Default value: ["optionalPeerDependencies"]
- * @param {string}   [options.name]  A unique name to use for this middleware.
- *                                   Default value is the "name" field from package.json.
- * @returns {function}               The generated require function.
+ * @param {Module}   baseModule            The module that hosts the dependencies.
+ * @param {Object}   [options]             Options object
+ * @param {string[]} [options.index]       Which dependencies to evaluate.
+ *                                         Default value: ["optionalPeerDependencies"]
+ * @param {string}   [options.name]        A unique name to use for this middleware.
+ *                                         Default value is the "name" field from package.json.
+ * @param {boolean}  [options.strictCheck] Check for `package.json` in base module only
+                                           Default value: true
+ * @returns {function}                     The generated require function.
  */
 
 exports.register = function (baseModule, options) {

--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ exports.register = function (baseModule, options) {
 
 	// find the nearest package.json
 
-	var pkg = exports.findPackage(baseModule, true);
+	var pkg = exports.findPackage(baseModule, options.strictCheck !== false);
 
 	// decide on a name for this middleware
 


### PR DESCRIPTION
This will allow registering from a submodule

```js
var codependency = require('codependency');
var requirePeer = codependency.register(module, { strictCheck: false });
```

fixes #4 
fixes #5 