### PR TITLE
fixed name resolution issue when handling scoped pacakges

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function isRealDepInPackage(pkg, name) {
 function realResolve(deps, baseMod, basePkg, name) {
 	var pos = name.indexOf('/');
 	if (pos !== -1) {
-		name = name.slice(0, pos);
+		name = name.replace(/(@[^\/]+\/)?([^\/]+).*/, '$1$2');
 	}
 
 	var range = deps[name];


### PR DESCRIPTION
Currently when trying to determine the package name we're stripping everything after the first `/`. However with the introduction of scoped packages this strips away the actual package name. I have replace this logic with a regex replace which preserves the scope (if present) and the contents before the first `/` thereafter.